### PR TITLE
[WINDOWS] Fix CYGWIN and MinGW build.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ libsbsmsincludedir = $(includedir)
 libsbsmsinclude_HEADERS = ../include/sbsms.h
 
 lib_LTLIBRARIES = libsbsms.la
+libsbsms_la_LDFLAGS = -no-undefined
 libsbsms_la_SOURCES = \
 	sms.cpp \
 	track.cpp \


### PR DESCRIPTION
I tried to make a package for CYGWIN and MinGW with libsbsms, but I discovered that the process fails because PE targets require the `-no-undefined` flag set for libtool, if you want to output a shared library.
Otherwise, it prints this message:
```
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
make[2]: *** [Makefile:462: libsbsms.la] Error 1
```
This patch fixes this problem.